### PR TITLE
Add missing package dependencies

### DIFF
--- a/modules/matterhorn-userdirectory-canvas/pom.xml
+++ b/modules/matterhorn-userdirectory-canvas/pom.xml
@@ -119,6 +119,10 @@
               !joptsimple,
               !org.aspectj.*,
               !net.sf.cglib.proxy,
+              javax.xml.namespace;version=0.0.0,
+              javax.xml.parsers;version=0.0.0,
+              javax.xml.transform;version=0.0.0,
+              javax.xml.transform.sax;version=0.0.0,
               *
             </Import-Package>
             <Service-Component>


### PR DESCRIPTION
These were required for the module to load on worker servers (and possibly others) in a distributed setup.